### PR TITLE
Fix toast auto-dismiss timing

### DIFF
--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,7 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+const TOAST_REMOVE_DELAY = 1000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- adjust toast remove delay from ~16 minutes to 1 second

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684107b0a718832690e3b1331b05957d